### PR TITLE
Feat/#55/channel crud

### DIFF
--- a/backend/src/channel/channel.controller.ts
+++ b/backend/src/channel/channel.controller.ts
@@ -8,7 +8,7 @@ export class ChannelController {
 
   @Get()
   async getAll() {
-    return this.channelService.getAll();
+    return this.channelService.getAllChannel();
   }
 
   @Post()

--- a/backend/src/channel/channel.module.ts
+++ b/backend/src/channel/channel.module.ts
@@ -2,14 +2,18 @@ import { Module } from '@nestjs/common';
 import { ChannelService } from './channel.service';
 import { ChannelController } from './channel.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { Channel } from './entity/channel.entity';
+import { Channel, ChannelMember } from './entity/channel.entity';
 import { ChannelGateway } from './channel.gateway';
 import { AuthModule } from 'src/auth/auth.module';
 import { UserModule } from 'src/user/user.module';
 import { ChannelSocketUserService } from './channel.socket-user.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Channel]), AuthModule, UserModule],
+  imports: [
+    TypeOrmModule.forFeature([Channel, ChannelMember]),
+    AuthModule,
+    UserModule,
+  ],
   providers: [ChannelService, ChannelGateway, ChannelSocketUserService],
   controllers: [ChannelController],
 })

--- a/backend/src/channel/channel.service.ts
+++ b/backend/src/channel/channel.service.ts
@@ -1,15 +1,43 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { ChannelListDto } from './dto/channel-list.dto';
 import { CreateChannelDto } from './dto/create-channel.dto';
-import { Channel } from './entity/channel.entity';
+import { Channel, ChannelMember } from './entity/channel.entity';
 
 @Injectable()
 export class ChannelService {
   constructor(
     @InjectRepository(Channel)
     private readonly channelRepository: Repository<Channel>,
+    @InjectRepository(ChannelMember)
+    private channelMemberRepository: Repository<ChannelMember>,
   ) {}
+
+  channelMap: Map<number, ChannelListDto> = new Map();
+
+  async onModuleInit() {
+    const channels: Channel[] = await this.channelRepository.find();
+    for (const channel of channels) {
+      const instance = new ChannelListDto();
+      instance.roomId = channel.id;
+      instance.title = channel.title;
+      instance.isProtected = channel.type === 2 ? true : false;
+      const memCnt = await this.channelMemberRepository.findAndCount({
+        where: {
+          channelID: channel.id,
+        },
+        join: {
+          alias: 'channel_member',
+          leftJoinAndSelect: {
+            channel: 'channel_member.channelID',
+          },
+        },
+      });
+      instance.memberCount = memCnt[1];
+      this.channelMap.set(instance.roomId, instance);
+    }
+  }
 
   async createChannel(channelData: CreateChannelDto) {
     const newChannel: Channel = this.channelRepository.create({
@@ -20,7 +48,7 @@ export class ChannelService {
     await this.channelRepository.insert(newChannel);
   }
 
-  async getAll() {
-    return this.channelRepository.find();
+  getAllChannel() {
+    return [...this.channelMap.values()];
   }
 }

--- a/backend/src/channel/dto/channel-list.dto.ts
+++ b/backend/src/channel/dto/channel-list.dto.ts
@@ -1,0 +1,13 @@
+// import { IsNumber, IsOptional, IsString } from 'class-validator';
+
+export class ChannelListDto {
+  roomId: number;
+
+  // @IsString()
+  title: string;
+
+  // @IsNumber()
+  isProtected: boolean;
+
+  memberCount: number;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import Game from './views/game/game';
 import Setting from './views/setting/setting';
 import OTP from './views/auth/otp/otp';
 import Chatroom from './views/chatroom/chatroom';
+import Channel from './channel/channel';
 
 function App() {
   return (
@@ -21,6 +22,7 @@ function App() {
       <Route path="/otp" component={OTP}/>
       <Route path="/register" component={Register}/>
       <Route path="/chatroom/:id" component={Chatroom}/>
+      <Route path="/channel" component={Channel}/>
     </div>
   );
 }

--- a/frontend/src/views/main/chatroomItem/item.tsx
+++ b/frontend/src/views/main/chatroomItem/item.tsx
@@ -2,18 +2,19 @@ import React, { useState } from 'react';
 import EnterPasswordModal from '../../../components/modal/chatroom/join/enterPasswordModal';
 import './item.scss';
 
-type chatroomItemProps = {
+export type chatroomItemProps = {
   roomId: number,
   title: string,
   memberCount: number,
   isProtected: boolean
 }
-function ChatroomItem(prop: chatroomItemProps) {
+
+const ChatroomItem = ({channel} : {channel:any}) => {
 
   const [modalopen, setModalOpen] = useState(false);
 
   const handleOnClick = () => {
-    if (prop.isProtected)
+    if (channel.isProtected)
       setModalOpen(true);
     else
       console.log("io.emit join!!")
@@ -28,10 +29,10 @@ function ChatroomItem(prop: chatroomItemProps) {
     <>
       <div className="chatroom-item" onClick={handleOnClick}>
         <div className="chatroom-header">
-          <div className="chatroom-title">{prop.title}</div>
-          { prop.isProtected ? <img className="chatroom-locked" alt="chatroom-locked" src="/icons/lock.svg"/> : ""}
+          <div className="chatroom-title">{channel.title}</div>
+          { channel.isProtected ? <img className="chatroom-locked" alt="chatroom-locked" src="/icons/lock.svg"/> : ""}
         </div>
-        <div className="chatroom-member-count">{prop.memberCount}명 참여중</div>
+        <div className="chatroom-member-count">{channel.memberCount}명 참여중</div>
       </div>
       {modalopen ? <EnterPasswordModal open={modalopen} close={handleModalClose}/> : ""}
     </>

--- a/frontend/src/views/main/main.tsx
+++ b/frontend/src/views/main/main.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
+import axios from 'axios';
+import React, { useEffect, useState } from 'react';
 import Button from '../../components/button/button';
 import EmptyPageInfo from '../../components/emptyPage/empty';
 import Header from '../../components/header/header';
 import ChatroomCreateModal from '../../components/modal/chatroom/create/chatroomCreateModal';
 import SideBar from '../../components/sideBar/sideBar';
-import ChatroomItem from './chatroomItem/item';
+import ChatroomItem, { chatroomItemProps } from './chatroomItem/item';
 import './main.scss';
 
 enum ChatroomCategory {
@@ -44,7 +45,27 @@ function Main() {
       setChatroomCategory(category);
     }
   }
+  const [channels, setChannels] = useState<chatroomItemProps[] | null>(null);
+  const [myChannels, setMyChannels] = useState<chatroomItemProps[] | null>(null);
 
+	useEffect(() => {
+		const fetchData = async () => {
+			try {
+				const response = await axios.get(`http://localhost:5000/channel`);
+        console.log(response);
+				setChannels(response.data);
+			}
+			catch (e) { console.log(e); }
+		};
+		fetchData();
+	}, []);
+
+	if (!channels) {
+		return (
+			<div>Loading..</div>
+		)
+	}
+  /*
   var tempAllChatroomList = [{ roomId: 42, title: "Libft 평가자 모십니다", memberCount: 42, isProtected: true }, 
                             { roomId: 42, title: "gnl에서 메모리 누수 어케 잡으셨나요..?", memberCount: 42, isProtected: true },
                             { roomId: 42, title: "netwhat 공부 어케했어요", memberCount: 42, isProtected: false },
@@ -78,7 +99,7 @@ function Main() {
                             { roomId: 42, title: "피아노 알려주세요 ㅠㅠ", memberCount: 42, isProtected: false },
                             { roomId: 42, title: "테트리스 잘하는 사람들의 모임", memberCount: 42, isProtected: false },
                             { roomId: 42, title: "슈퍼 겁쟁이들의 모임", memberCount: 42, isProtected: false }, ];
-
+  */
   // to test empty info
   // tempAllChatroomList = [];
   // tempJoinedChatroomList = [];
@@ -100,18 +121,21 @@ function Main() {
             </div>
           </div>
 
-          {(chatroomCategory === ChatroomCategory.AllChatroomList && tempAllChatroomList.length === 0) 
+          {(chatroomCategory === ChatroomCategory.AllChatroomList && !channels) 
             ? <EmptyPageInfo description={`공개 채팅방이 존재하지 않습니다.\n'채팅방 만들기' 버튼으로 채팅방을 생성해보세요!`}/>
-            : (chatroomCategory === ChatroomCategory.JoinedChatroomList && tempJoinedChatroomList.length === 0)
+            : (chatroomCategory === ChatroomCategory.JoinedChatroomList && !myChannels)
               ? <EmptyPageInfo description={`현재 참여중인 채팅방이 없습니다.\n전체 채팅방 목록에서 참가해보세요!`}/> 
               : <div className="chatroom-list">
                   {chatroomCategory === ChatroomCategory.AllChatroomList 
-                    ? tempAllChatroomList.map(item => (
-                        <ChatroomItem roomId={item.roomId} title={item.title} memberCount={item.memberCount} isProtected={item.isProtected}/>
+                    ? channels.map(item => (
+                        <ChatroomItem 
+                        channel = {item} 
+                        key = {item.roomId}/>
                       ))
-                    : tempJoinedChatroomList.map(item => (
-                        <ChatroomItem roomId={item.roomId} title={item.title} memberCount={item.memberCount} isProtected={item.isProtected}/>
-                      ))
+                    // : myChannels.map(item => (
+                    //     <ChatroomItem roomId={item.roomId} title={item.title} memberCount={item.memberCount} isProtected={item.isProtected}/>
+                    //   ))
+                       : null
                   }
                 </div>
           }


### PR DESCRIPTION
[channel READ 관련]
**BACK**
- Channel List 반환용 dto 생성 (ChannelListDto)
- 현재 Repository API 이용해서 단순하게 channel entity 반환하는 부분 수정하기
    - Password 제외하고, 참여중인 인원수, 비밀방여부 포함
    - typeORM에서 join 이용해 transaction
    - channel.service.ts 에서 Lifecycle hook 이용해 서버 실행시 DB에서 채팅방 리스트 읽어와서 Map 변수에 저장
    - 전체 채팅방 목록을 반환하는 endpoint에서는 해당 Map 의 value 배열만 반환

**FRONT**
- axios로 channel list 가져온 후 map 으로 순환하면서 channelItem 에 props 넘겨서 컴포넌트 렌더링 해주기
- 함수형 컴포넌트로 변경 예정

[channel CREATE 관련]
- channel CREATE 시 현재 유저 정보를 가져와서 자동으로 owner 가 되게끔 하려고 했는데
- channel module 에 Jwt AuthGuard 붙이면 401 Unauthorized 오류가 발생해서 못하고 있는 중 ㅠㅠ

현재성과
![image](https://user-images.githubusercontent.com/13804135/135745937-9ca381d6-20d7-4b7e-b7ce-2e63109a4923.png)