### PR TITLE
TMP: add docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+version: '3'
+
+services:
+  db:
+    image: postgres
+    container_name: db
+    volumes:
+      - ./docker/data:/var/lib/postgresql/data
+      - ./docker/init-user-db.sh:/docker-entrypoint-initdb.d/init-user-db.sh
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=postgres
+      - POSTGRES_PASSWORD=test
+      - POSTGRES_INITDB_ARGS=--encoding=UTF-8
+    user: postgres
+    ports:
+      - "5432:5432"
+  
+  backend:
+    image: node:lts-alpine3.13
+    container_name: backend
+    env_file: ./backend/.env
+    volumes:
+      - ./backend:/backend
+    working_dir: /backend
+    ports:
+      - "5000:5000"
+    depends_on:
+      - db
+    entrypoint: >
+      sh -c "npm install
+      && npm run start:dev"
+  
+  frontend:
+    image: node:lts-alpine3.13
+    container_name: frontend
+    env_file: ./frontend/.env
+    volumes:
+      - ./frontend:/frontend
+    working_dir: /frontend
+    ports:
+      - "3000:3000"
+    entrypoint: >
+      sh -c "npm install
+      && npm start"
+      

--- a/docker/init-user-db.sh
+++ b/docker/init-user-db.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    CREATE USER hysimok;
+    CREATE DATABASE t11e;
+    GRANT ALL PRIVILEGES ON DATABASE t11e TO hysimok;
+EOSQL


### PR DESCRIPTION
postgres 에서 db 설정 관련 오류가 끝이 없네요. 
Dockerfile 없이 docker-compose.yml 파일만으로 깔끔하게 해보려고 했는데
permission 문제 때문에 db 생성하는 sql문 실행을 못하네요.

지금 올리는게 작동하는 버전은 아니지만 기록해두고 다른 방법 시도해보려고 PR로 남겨둡니다.
삽질기는 시간이 되면 정리해보겠음...